### PR TITLE
Refactor error codes. Provide information return information on invald signature

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -57,7 +57,7 @@ func ExampleNewHandler() {
 	myhandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Lookup the results of verification
 		if veriftyResult, ok := httpsig.GetVerifyResult(r.Context()); ok {
-			keyid, _ := veriftyResult.KeyID()
+			keyid, _ := veriftyResult.Signature().Metadata.KeyID()
 			fmt.Fprintf(w, "Hello, %s", keyid)
 		} else {
 			fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))

--- a/fz_test.go
+++ b/fz_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/remitly-oss/httpsig-go/sigtest"
 )
 
 // FuzzSigningOptions fuzzes the basic user input to SigningOptions
@@ -43,7 +45,7 @@ func FuzzSigningOptions1(f *testing.F) {
 			},
 		})
 		so := SigningOptions{
-			PrivateKey: readTestPrivateKey(t, "test-key-ed25519.key"),
+			PrivateKey: sigtest.ReadTestPrivateKey(t, "test-key-ed25519.key"),
 			Algorithm:  Algo_ED25519,
 			Fields:     Fields(label, keyID, tag),
 			Metadata:   []Metadata{MetaKeyID, MetaTag},
@@ -111,7 +113,7 @@ func FuzzSigningOptionsFields(f *testing.F) {
 			})
 		}
 		so := SigningOptions{
-			PrivateKey: readTestPrivateKey(t, "test-key-ed25519.key"),
+			PrivateKey: sigtest.ReadTestPrivateKey(t, "test-key-ed25519.key"),
 			Algorithm:  Algo_ED25519,
 			Fields:     fields,
 		}
@@ -182,7 +184,7 @@ func FuzzMetadata(f *testing.F) {
 		t.Logf("tag: %s\n", tag)
 
 		so := SigningOptions{
-			PrivateKey: readTestPrivateKey(t, "test-key-ed25519.key"),
+			PrivateKey: sigtest.ReadTestPrivateKey(t, "test-key-ed25519.key"),
 			Algorithm:  Algo_ED25519,
 			Fields:     Fields(),
 			Metadata:   []Metadata{MetaCreated, MetaExpires, MetaNonce, MetaAlgorithm, MetaKeyID, MetaTag},

--- a/keyutil/keyutil.go
+++ b/keyutil/keyutil.go
@@ -81,6 +81,14 @@ func MustReadPrivateKeyFile(pkFile string, override ...Format) crypto.PrivateKey
 	return pk
 }
 
+func MustReadPrivateKey(encodedPrivateKey []byte, override ...Format) crypto.PrivateKey {
+	pkey, err := ReadPrivateKey(encodedPrivateKey, override...)
+	if err != nil {
+		panic(err)
+	}
+	return pkey
+}
+
 // ReadPrivateKeyFile decodes a PEM encoded private key file and parses into a crypto.PrivateKey
 func ReadPrivateKeyFile(pkFile string, override ...Format) (crypto.PrivateKey, error) {
 	keyBytes, err := os.ReadFile(pkFile)

--- a/sigerrors.go
+++ b/sigerrors.go
@@ -1,0 +1,69 @@
+package httpsig
+
+import "fmt"
+
+// ErrCode enumerates the reasons a signing or verification can fail
+type ErrCode string
+
+const (
+	// Error Codes
+
+	// Errors related to not being able to extract a valid signature.
+	ErrNoSigInvalidHeader     ErrCode = "nosig_invalid_header"
+	ErrNoSigUnsupportedDigest ErrCode = "nosig_unsupported_digest"
+	ErrNoSigWrongDigest       ErrCode = "nosig_wrong_digest"
+	ErrNoSigMissingSignature  ErrCode = "nosig_missing_signature"
+	ErrNoSigInvalidSignature  ErrCode = "nosig_invalid_signature"
+	ErrNoSigMessageBody       ErrCode = "nosig_message_body" // Could not read message body
+
+	// Errors related to an individual signature.
+	ErrSigInvalidSignature     ErrCode = "sig_invalid_signature"        // The signature is unparseable or in the wrong format.
+	ErrSigKeyFetch             ErrCode = "sig_key_fetch"                // Failed to the key for a signature
+	ErrSigVerification         ErrCode = "sig_failed_algo_verification" // The signature did not verify according to the algorithm.
+	ErrSigPublicKey            ErrCode = "sig_public_key"               // The public key for the signature is invalid or missing.
+	ErrSigSecretKey            ErrCode = "sig_secret_key"               // The secret key for the signature is invalid or missing.
+	ErrSigUnsupportedAlgorithm ErrCode = "sig_unsupported_algorithm"    // unsupported or invalid algorithm.
+	ErrSigProfile              ErrCode = "sig_failed_profile"           // The signature was valid but failed the verify profile check
+
+	// Signing
+	ErrInvalidSignatureOptions ErrCode = "invalid_signature_options"
+	ErrInvalidComponent        ErrCode = "invalid_component"
+	ErrInvalidMetadata         ErrCode = "invalid_metadata"
+
+	ErrInternal    ErrCode = "internal_error"
+	ErrUnsupported ErrCode = "unsupported" // A particular feature of the spec is not supported
+)
+
+type SignatureError struct {
+	Cause   error // may be nil
+	Code    ErrCode
+	Message string
+}
+
+func (se *SignatureError) Error() string {
+	return se.Message
+}
+
+func (se *SignatureError) Unwrap() error {
+	return se.Cause
+}
+
+func (se *SignatureError) GoString() string {
+	cause := ""
+	if se.Cause != nil {
+		cause = fmt.Sprintf("Cause: %s\n", se.Cause)
+	}
+	return fmt.Sprintf("Code: %s\nMessage: %s\n%s", se.Code, se.Message, cause)
+}
+
+func newError(code ErrCode, msg string, cause ...error) *SignatureError {
+	var rootErr error
+	if len(cause) > 0 {
+		rootErr = cause[0]
+	}
+	return &SignatureError{
+		Cause:   rootErr,
+		Code:    code,
+		Message: msg,
+	}
+}

--- a/signatures.go
+++ b/signatures.go
@@ -77,7 +77,7 @@ func sign(hrr httpMessage, sp sigParameters) error {
 			msgHash := sha256.Sum256(base.base)
 			r, s, err := ecdsa.Sign(rand.Reader, eccpk, msgHash[:])
 			if err != nil {
-				return newError(ErrVerification, "Failed to sign with ecdsa private key", err)
+				return newError(ErrInternal, "Failed to sign with ecdsa private key", err)
 			}
 			// Concatenate r and s to make the signature as per the spec. r and s are *not* encoded in ASN1 format
 			sigBytes = make([]byte, 64)
@@ -91,7 +91,7 @@ func sign(hrr httpMessage, sp sigParameters) error {
 			msgHash := sha512.Sum384(base.base)
 			r, s, err := ecdsa.Sign(rand.Reader, eccpk, msgHash[:])
 			if err != nil {
-				return newError(ErrVerification, "Failed to sign with ecdsa private key", err)
+				return newError(ErrInternal, "Failed to sign with ecdsa private key", err)
 			}
 			// Concatenate r and s to make the signature as per the spec. r and s are *not* encoded in ASN1 format
 			sigBytes = make([]byte, 96)
@@ -114,13 +114,13 @@ func sign(hrr httpMessage, sp sigParameters) error {
 		msgHash.Write(base.base) // write does not return an error per hash.Hash documentation
 		sigBytes = msgHash.Sum(nil)
 	default:
-		return newError(ErrInvalidAlgorithm, fmt.Sprintf("Signing algorithm not supported: '%s'", sp.Algo))
+		return newError(ErrInvalidSignatureOptions, fmt.Sprintf("Signing algorithm not supported: '%s'", sp.Algo))
 	}
 	sigField := sfv.NewDictionary()
 	sigField.Add(sp.Label, sfv.NewItem(sigBytes))
 	signature, err := sfv.Marshal(sigField)
 	if err != nil {
-		return newError(ErrInvalidAlgorithm, fmt.Sprintf("bad marshal - label; %s", sp.Label), err)
+		return newError(ErrInternal, fmt.Sprintf("Failed to marshal signature for label '%s'", sp.Label), err)
 	}
 	hrr.Headers().Set("Signature-Input", fmt.Sprintf("%s=%s", sp.Label, base.signatureInput))
 	hrr.Headers().Set("Signature", signature)

--- a/sigtest/helpers.go
+++ b/sigtest/helpers.go
@@ -1,0 +1,85 @@
+package sigtest
+
+import (
+	"bufio"
+	"bytes"
+	"crypto"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/remitly-oss/httpsig-go/keyutil"
+)
+
+func ReadRequest(t testing.TB, reqFile string) *http.Request {
+	reqtxt, err := os.Open(fmt.Sprintf("testdata/%s", reqFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req, err := http.ReadRequest(bufio.NewReader(reqtxt))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return req
+}
+
+func MustReadFile(file string) []byte {
+	data, err := os.ReadFile(file)
+	if err != nil {
+		panic(err)
+	}
+	return data
+}
+
+func MakeBody(body string) io.ReadCloser {
+	return io.NopCloser(bytes.NewReader([]byte(body)))
+}
+
+func ReadSharedSecret(t *testing.T, sharedSecretFile string) []byte {
+	secretBytes, err := os.ReadFile(fmt.Sprintf("testdata/%s", sharedSecretFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	secret, err := base64.StdEncoding.DecodeString(string(secretBytes))
+	if err != nil {
+		t.Fatal(err)
+	}
+	return secret
+}
+
+func ReadTestPubkey(t *testing.T, pubkeyFile string) crypto.PublicKey {
+	keybytes, err := os.ReadFile(fmt.Sprintf("testdata/%s", pubkeyFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pubkey, err := keyutil.ReadPublicKey(keybytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pubkey
+}
+
+func ReadTestPrivateKey(t testing.TB, pkFile string, hint ...string) crypto.PrivateKey {
+	keybytes, err := os.ReadFile(fmt.Sprintf("testdata/%s", pkFile))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkey, err := keyutil.ReadPrivateKey(keybytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return pkey
+}
+
+func Diff(t *testing.T, expected, actual interface{}, msg string, opts ...cmp.Option) bool {
+	if diff := cmp.Diff(expected, actual, opts...); diff != "" {
+		t.Errorf("%s (-want +got):\n%s", msg, diff)
+		return true
+	}
+	return false
+}

--- a/spec_test.go
+++ b/spec_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 	"testing"
+
+	"github.com/remitly-oss/httpsig-go/sigtest"
 )
 
 /*
@@ -26,7 +28,7 @@ func TestSpecVerify(t *testing.T) {
 			Key: KeySpec{
 				KeyID:  "test-key-rsa-pss",
 				Algo:   Algo_RSA_PSS_SHA512,
-				PubKey: readTestPubkey(t, "test-key-rsa-pss.pub"),
+				PubKey: sigtest.ReadTestPubkey(t, "test-key-rsa-pss.pub"),
 			},
 			SignedRequestOrResonseFile: "b21_request_signed.txt",
 		},
@@ -35,7 +37,7 @@ func TestSpecVerify(t *testing.T) {
 			Key: KeySpec{
 				KeyID:  "test-key-rsa-pss",
 				Algo:   Algo_RSA_PSS_SHA512,
-				PubKey: readTestPubkey(t, "test-key-rsa-pss.pub"),
+				PubKey: sigtest.ReadTestPubkey(t, "test-key-rsa-pss.pub"),
 			},
 			SignedRequestOrResonseFile: "b22_request_signed.txt",
 		},
@@ -44,7 +46,7 @@ func TestSpecVerify(t *testing.T) {
 			Key: KeySpec{
 				KeyID:  "test-key-rsa-pss",
 				Algo:   Algo_RSA_PSS_SHA512,
-				PubKey: readTestPubkey(t, "test-key-rsa-pss.pub"),
+				PubKey: sigtest.ReadTestPubkey(t, "test-key-rsa-pss.pub"),
 			},
 			SignedRequestOrResonseFile: "b23_request_signed.txt",
 		},
@@ -54,7 +56,7 @@ func TestSpecVerify(t *testing.T) {
 			Key: KeySpec{
 				KeyID:  "test-key-ecc-p256",
 				Algo:   Algo_ECDSA_P256_SHA256,
-				PubKey: readTestPubkey(t, "test-key-ecc-p256.pub"),
+				PubKey: sigtest.ReadTestPubkey(t, "test-key-ecc-p256.pub"),
 			},
 			SignedRequestOrResonseFile: "b24_response_signed.txt",
 		},
@@ -63,7 +65,7 @@ func TestSpecVerify(t *testing.T) {
 			Key: KeySpec{
 				KeyID:  "test-shared-secret",
 				Algo:   Algo_HMAC_SHA256,
-				Secret: readSharedSecret(t, "test-shared-secret"),
+				Secret: sigtest.ReadSharedSecret(t, "test-shared-secret"),
 			},
 			SignedRequestOrResonseFile: "b25_request_signed.txt",
 		},
@@ -72,7 +74,7 @@ func TestSpecVerify(t *testing.T) {
 			Key: KeySpec{
 				KeyID:  "test-key-ed25519",
 				Algo:   Algo_ED25519,
-				PubKey: readTestPubkey(t, "test-key-ed25519.pub"),
+				PubKey: sigtest.ReadTestPubkey(t, "test-key-ed25519.pub"),
 			},
 			SignedRequestOrResonseFile: "b26_request_signed.txt",
 		},
@@ -317,7 +319,7 @@ func TestSpecRecreateSignature(t *testing.T) {
 				},
 				Algo:   Algo_HMAC_SHA256,
 				Label:  "sig-b25",
-				Secret: readSharedSecret(t, "test-shared-secret"),
+				Secret: sigtest.ReadSharedSecret(t, "test-shared-secret"),
 			},
 
 			ExpectedFile: "b25_request_signed.txt",
@@ -341,7 +343,7 @@ func TestSpecRecreateSignature(t *testing.T) {
 
 				Algo:       Algo_ED25519,
 				Label:      "sig-b26",
-				PrivateKey: readTestPrivateKey(t, "test-key-ed25519.key"),
+				PrivateKey: sigtest.ReadTestPrivateKey(t, "test-key-ed25519.key"),
 			},
 			ExpectedFile: "b26_request_signed.txt",
 		},
@@ -374,7 +376,7 @@ func TestSpecRecreateSignature(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			Diff(t, expected.Header, req.Header, "")
+			sigtest.Diff(t, expected.Header, req.Header, "")
 		})
 	}
 }

--- a/testdata/verify_request1.txt
+++ b/testdata/verify_request1.txt
@@ -1,0 +1,10 @@
+POST /foo?param=Value&Pet=dog HTTP/1.1
+Host: example.com
+Date: Tue, 20 Apr 2021 02:07:55 GMT
+Content-Type: application/json
+Content-Digest: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:
+Content-Length: 18
+Signature-Input: sig-b21=();created=1618884473;keyid="test-key-rsa-pss";nonce="b3k2pp5k7z-50gnwp.yemd"
+Signature: sig-b21=:d2pmTvmbncD3xQm8E9ZV2828BjQWGgiwAaw5bAkgibUopemLJcWDy/lkbbHAve4cRAtx31Iq786U7it++wgGxbtRxf8Udx7zFZsckzXaJMkA7ChG52eSkFxykJeNqsrWH5S+oxNFlD4dzVuwe8DhTSja8xxbR/Z2cOGdCbzR72rgFWhzx2VjBqJzsPLMIQKhO4DGezXehhWwE56YCE+O6c0mKZsfxVrogUvA4HELjVKWmAvtl6UnCh8jYzuVG5WSb/QEVPnP5TmcAnLH1g+s++v6d4s8m0gCw1fV5/SITLq9mhho8K3+7EPYTU8IU1bLhdxO5Nyt8C8ssinQ98Xw9Q==:
+
+{"hello": "world"}

--- a/testdata/verify_request2.txt
+++ b/testdata/verify_request2.txt
@@ -1,0 +1,10 @@
+POST /foo?param=Value&Pet=dog HTTP/1.1
+Host: example.com
+Date: Tue, 20 Apr 2021 02:07:55 GMT
+Content-Type: application/json
+Content-Digest: sha-512=:WZDPaVn/7XgHaAy8pmojAkGWoRx2UFChF41A2svX+TaPm+AbwAgBWnrIiYllu7BNNyealdVLvRwEmTHWXvJwew==:
+Content-Length: 18
+Signature-Input: sig-b21=();created=1618884473;keyid="test-key-rsa-pss";nonce="b3k2pp5k7z-50gnwp.yemd",bad-sig=("@authority");created=1618884473;keyid="test-key-rsa-pss"
+Signature: sig-b21=:d2pmTvmbncD3xQm8E9ZV2828BjQWGgiwAaw5bAkgibUopemLJcWDy/lkbbHAve4cRAtx31Iq786U7it++wgGxbtRxf8Udx7zFZsckzXaJMkA7ChG52eSkFxykJeNqsrWH5S+oxNFlD4dzVuwe8DhTSja8xxbR/Z2cOGdCbzR72rgFWhzx2VjBqJzsPLMIQKhO4DGezXehhWwE56YCE+O6c0mKZsfxVrogUvA4HELjVKWmAvtl6UnCh8jYzuVG5WSb/QEVPnP5TmcAnLH1g+s++v6d4s8m0gCw1fV5/SITLq9mhho8K3+7EPYTU8IU1bLhdxO5Nyt8C8ssinQ98Xw9Q==:,bad-sig=:pxcQw6G3AjtMBQjwo8XzkZf/bws5LelbaMk5rGIGtE8=:
+
+{"hello": "world"}

--- a/verify_test.go
+++ b/verify_test.go
@@ -1,0 +1,239 @@
+package httpsig_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/remitly-oss/httpsig-go"
+	"github.com/remitly-oss/httpsig-go/keyman"
+	"github.com/remitly-oss/httpsig-go/keyutil"
+	"github.com/remitly-oss/httpsig-go/sigtest"
+)
+
+func TestVerify(t *testing.T) {
+	testcases := []struct {
+		Name        string
+		RequestFile string
+		Keys        httpsig.KeyFetcher
+		Expected    httpsig.VerifyResult
+	}{
+		{
+			Name:        "OneValid",
+			RequestFile: "verify_request1.txt",
+			Keys: keyman.NewKeyFetchInMemory(map[string]httpsig.KeySpec{
+				"test-key-rsa-pss": {
+					KeyID:  "test-key-rsa-pss",
+					Algo:   httpsig.Algo_RSA_PSS_SHA512,
+					PubKey: keyutil.MustReadPublicKeyFile("testdata/test-key-rsa-pss.pub"),
+				},
+			}),
+			Expected: httpsig.VerifyResult{
+				Signatures: map[string]httpsig.VerifiedSignature{
+					"sig-b21": {
+						Label: "sig-b21",
+						Metadata: &fixedMetadataProvider{map[httpsig.Metadata]any{
+							httpsig.MetaKeyID:   "test-key-rsa-pss",
+							httpsig.MetaCreated: int64(1618884473),
+							httpsig.MetaNonce:   "b3k2pp5k7z-50gnwp.yemd",
+						}},
+					},
+				},
+				InvalidSignatures: map[string]httpsig.InvalidSignature{},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			actual, err := httpsig.Verify(sigtest.ReadRequest(t, tc.RequestFile), tc.Keys, httpsig.DefaultVerifyProfile)
+			if err != nil {
+				t.Fatal(err)
+			}
+			// VerifyResult is returned even when error is also returned.
+			sigtest.Diff(t, tc.Expected, actual, "Did not match", getCmdOpts()...)
+		})
+	}
+}
+
+func TestVerifyInvalid(t *testing.T) {
+	testcases := []struct {
+		Name        string
+		RequestFile string
+		Keys        httpsig.KeyFetcher
+		Expected    httpsig.VerifyResult
+	}{
+		{
+			Name:        "ExtractFailure",
+			RequestFile: "verify_request2.txt",
+			Keys: keyman.NewKeyFetchInMemory(map[string]httpsig.KeySpec{
+				"test-key-rsa-pss": {
+					KeyID:  "test-key-rsa-pss",
+					Algo:   httpsig.Algo_RSA_PSS_SHA512,
+					PubKey: keyutil.MustReadPublicKeyFile("testdata/test-key-rsa-pss.pub"),
+				},
+			}),
+			Expected: httpsig.VerifyResult{
+				Signatures: map[string]httpsig.VerifiedSignature{
+					"sig-b21": {
+						Label: "sig-b21",
+						Metadata: &fixedMetadataProvider{map[httpsig.Metadata]any{
+							httpsig.MetaKeyID:   "test-key-rsa-pss",
+							httpsig.MetaCreated: int64(1618884473),
+							httpsig.MetaNonce:   "b3k2pp5k7z-50gnwp.yemd",
+						}},
+					},
+				},
+				InvalidSignatures: map[string]httpsig.InvalidSignature{
+					"bad-sig": createInvalidSignature(httpsig.InvalidSignature{
+						Label:       "bad-sig",
+						HasMetadata: true,
+					}, &fixedMetadataProvider{map[httpsig.Metadata]any{
+						httpsig.MetaKeyID:   "test-key-rsa-pss",
+						httpsig.MetaCreated: int64(1618884473),
+					}}),
+				},
+			},
+		},
+		{
+			Name:        "OneValid-OneInvalid",
+			RequestFile: "verify_request2.txt",
+			Keys: keyman.NewKeyFetchInMemory(map[string]httpsig.KeySpec{
+				"test-key-rsa-pss": {
+					KeyID:  "test-key-rsa-pss",
+					Algo:   httpsig.Algo_RSA_PSS_SHA512,
+					PubKey: keyutil.MustReadPublicKeyFile("testdata/test-key-rsa-pss.pub"),
+				},
+			}),
+			Expected: httpsig.VerifyResult{
+				Signatures: map[string]httpsig.VerifiedSignature{
+					"sig-b21": {
+						Label: "sig-b21",
+						Metadata: &fixedMetadataProvider{map[httpsig.Metadata]any{
+							httpsig.MetaKeyID:   "test-key-rsa-pss",
+							httpsig.MetaCreated: int64(1618884473),
+							httpsig.MetaNonce:   "b3k2pp5k7z-50gnwp.yemd",
+						}},
+					},
+				},
+				InvalidSignatures: map[string]httpsig.InvalidSignature{
+					"bad-sig": createInvalidSignature(httpsig.InvalidSignature{
+						Label:       "bad-sig",
+						HasMetadata: true,
+					}, &fixedMetadataProvider{map[httpsig.Metadata]any{
+						httpsig.MetaKeyID:   "test-key-rsa-pss",
+						httpsig.MetaCreated: int64(1618884473),
+					}}),
+				},
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			actual, err := httpsig.Verify(sigtest.ReadRequest(t, tc.RequestFile), tc.Keys, httpsig.DefaultVerifyProfile)
+			if err == nil {
+				t.Fatal("Expected verify error and invalid sigature responsse")
+			}
+			// VerifyResult is returned even when error is also returned.
+			sigtest.Diff(t, tc.Expected, actual, "Did not match", getCmdOpts()...)
+		})
+	}
+}
+
+type fixedMetadataProvider struct {
+	values map[httpsig.Metadata]any
+}
+
+func (fmp fixedMetadataProvider) Created() (int, error) {
+	if val, ok := fmp.values[httpsig.MetaCreated]; ok {
+		return int(val.(int64)), nil
+	}
+	return 0, fmt.Errorf("No created value")
+}
+
+func (fmp fixedMetadataProvider) Expires() (int, error) {
+	if val, ok := fmp.values[httpsig.MetaExpires]; ok {
+		return int(val.(int64)), nil
+	}
+	return 0, fmt.Errorf("No expires value")
+}
+
+func (fmp fixedMetadataProvider) Nonce() (string, error) {
+	if val, ok := fmp.values[httpsig.MetaNonce]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("No nonce value")
+}
+
+func (fmp fixedMetadataProvider) Alg() (string, error) {
+	if val, ok := fmp.values[httpsig.MetaAlgorithm]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("No alg value")
+}
+
+func (fmp fixedMetadataProvider) KeyID() (string, error) {
+	if val, ok := fmp.values[httpsig.MetaKeyID]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("No keyid value")
+}
+
+func (fmp fixedMetadataProvider) Tag() (string, error) {
+	if val, ok := fmp.values[httpsig.MetaTag]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("No tag value")
+}
+
+func metaVal[E comparable](f1 func() (E, error)) any {
+	val, err := f1()
+	if err != nil {
+		return err.Error()
+	}
+	return val
+}
+
+func getCmdOpts() []cmp.Option {
+	return []cmp.Option{
+		cmp.Transformer("Metadata", TransformMeta),
+		cmp.Transformer("InvalidSignature", TransformInvalidSig),
+	}
+
+}
+func TransformMeta(md httpsig.MetadataProvider) map[string]any {
+	out := map[string]any{}
+
+	out[string(httpsig.MetaCreated)] = metaVal(md.Created)
+	out[string(httpsig.MetaExpires)] = metaVal(md.Expires)
+	out[string(httpsig.MetaNonce)] = metaVal(md.Nonce)
+	out[string(httpsig.MetaAlgorithm)] = metaVal(md.Alg)
+	out[string(httpsig.MetaKeyID)] = metaVal(md.KeyID)
+	out[string(httpsig.MetaTag)] = metaVal(md.Tag)
+	return out
+}
+
+func TransformInvalidSig(isig httpsig.InvalidSignature) map[string]any {
+
+	out := map[string]any{
+		"Label":       isig.Label,
+		"Raw":         isig.Raw,
+		"Error":       isig.Raw,
+		"HasMetadata": isig.HasMetadata,
+	}
+	if md, ok := isig.Metadata(); ok {
+		out["Metadata"] = TransformMeta(md)
+	}
+
+	return out
+}
+
+func createInvalidSignature(input httpsig.InvalidSignature, md httpsig.MetadataProvider) httpsig.InvalidSignature {
+	is := httpsig.NewInvalidSignature(md)
+	is.Error = input.Error
+	is.HasMetadata = input.HasMetadata
+	is.Label = input.Label
+	is.Raw = input.Raw
+	return is
+}


### PR DESCRIPTION
This change does two things:
- Refactors the error codes to be clear about errors that prevented signatures from being parsed at all from errors related to a single signature
- Provides information in verification results about invalid signatures to allow for introspection.

Additionally some of the test helpers were moved to its own package.