### PR TITLE
Add logic for parsing an Accept-Signature value

### DIFF
--- a/accept.go
+++ b/accept.go
@@ -1,0 +1,57 @@
+package httpsig
+
+import (
+	"fmt"
+
+	sfv "github.com/dunglas/httpsfv"
+)
+
+func ParseAcceptSignature(acceptHeader string) (SigningOptions, error) {
+	acceptDict, err := sfv.UnmarshalDictionary([]string{acceptHeader})
+	if err != nil {
+		return SigningOptions{}, newError(ErrInvalidAcceptSignature, "Unable to parse Accept-Signature value", err)
+	}
+	profiles := acceptDict.Names()
+	if len(profiles) == 0 {
+		return SigningOptions{}, newError(ErrMissingAcceptSignature, "No Accept-Signature value")
+	}
+
+	label := profiles[0]
+	profileItems, _ := acceptDict.Get(label)
+	profileList, isList := profileItems.(sfv.InnerList)
+	if !isList {
+		return SigningOptions{}, newError(ErrInvalidAcceptSignature, "Unable to parse Accept-Signature value. Accept-Signature must be a dictionary.")
+	}
+
+	fields := []string{}
+	for _, componentItem := range profileList.Items {
+		field, ok := componentItem.Value.(string)
+		if !ok {
+			return SigningOptions{}, newError(ErrInvalidAcceptSignature, fmt.Sprintf("Invalid signature component '%v', Components must be strings", componentItem.Value))
+
+		}
+		fields = append(fields, field)
+	}
+	so := SigningOptions{
+		Fields:   Fields(fields...),
+		Label:    label,
+		Metadata: []Metadata{},
+	}
+
+	md := metadataProviderFromParams{profileList.Params}
+	for _, meta := range profileList.Params.Names() {
+		so.Metadata = append(so.Metadata, Metadata(meta))
+		switch Metadata(meta) {
+		case MetaAlgorithm:
+			alg, _ := md.Alg()
+			so.Algorithm = Algorithm(alg)
+		case MetaKeyID:
+			so.MetaKeyID, _ = md.KeyID()
+		case MetaTag:
+			so.MetaTag, _ = md.Tag()
+		}
+	}
+
+	return so, nil
+
+}

--- a/accept_test.go
+++ b/accept_test.go
@@ -1,0 +1,62 @@
+package httpsig
+
+import (
+	"testing"
+
+	"github.com/remitly-oss/httpsig-go/sigtest"
+)
+
+func TestAcceptParseSignature(t *testing.T) {
+	testcases := []struct {
+		Name            string
+		Desc            string
+		AcceptHeader    string
+		Expected        SigningOptions
+		ExpectedErrCode ErrCode
+	}{
+		{
+			Name:         "FromSpecification",
+			Desc:         "Accept header used in the RFC",
+			AcceptHeader: `sig1=("@method" "@target-uri" "@authority" "content-digest" "cache-control");keyid="test-key-rsa-pss";created;tag="app-123"`,
+			Expected: SigningOptions{
+				Fields:    Fields("@method", "@target-uri", "@authority", "content-digest", "cache-control"),
+				Metadata:  []Metadata{"keyid", "created", "tag"},
+				Label:     "sig1",
+				MetaKeyID: "test-key-rsa-pss",
+				MetaTag:   "app-123",
+			},
+		},
+		{
+			Name:         "InvalidAcceptSig",
+			AcceptHeader: `("@method" "@target-uri" "@authority" "content-digest" "cache-control");keyid="test-key-rsa-pss";created;tag="app-123"`,
+
+			ExpectedErrCode: ErrInvalidAcceptSignature,
+		},
+		{
+			Name:            "NoAcceptSig",
+			AcceptHeader:    "",
+			ExpectedErrCode: ErrMissingAcceptSignature,
+		},
+		{
+			Name:            "NotAList",
+			AcceptHeader:    `sig1="@method"`,
+			ExpectedErrCode: ErrInvalidAcceptSignature,
+		},
+		{
+			Name:            "BadComponent",
+			AcceptHeader:    `sig1=("@method" 1 "@authority" "content-digest" "cache-control");keyid="test-key-rsa-pss";created;tag="app-123"`,
+			ExpectedErrCode: ErrInvalidAcceptSignature,
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			actual, err := ParseAcceptSignature(tc.AcceptHeader)
+			if sigtest.Diff(t, tc.ExpectedErrCode, errCode(err), "Wrong error code") {
+				t.Logf("%+v\n", err)
+				return
+			}
+			sigtest.Diff(t, tc.Expected, actual, "Wrong signature options")
+		})
+	}
+}

--- a/sigerrors.go
+++ b/sigerrors.go
@@ -1,6 +1,9 @@
 package httpsig
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // ErrCode enumerates the reasons a signing or verification can fail
 type ErrCode string
@@ -30,6 +33,11 @@ const (
 	ErrInvalidComponent        ErrCode = "invalid_component"
 	ErrInvalidMetadata         ErrCode = "invalid_metadata"
 
+	// Accept Signature
+	ErrInvalidAcceptSignature ErrCode = "invalid_accept_signature"
+	ErrMissingAcceptSignature ErrCode = "missing_accept_signature" // The Accept-Signature field was present but had an empty value.
+
+	// General
 	ErrInternal    ErrCode = "internal_error"
 	ErrUnsupported ErrCode = "unsupported" // A particular feature of the spec is not supported
 )
@@ -66,4 +74,16 @@ func newError(code ErrCode, msg string, cause ...error) *SignatureError {
 		Code:    code,
 		Message: msg,
 	}
+}
+
+func errCode(err error) (ec ErrCode) {
+	if err == nil {
+		return ""
+	}
+	var se *SignatureError
+	if errors.As(err, &se) {
+		return se.Code
+	}
+
+	return ""
 }

--- a/sign_test.go
+++ b/sign_test.go
@@ -2,7 +2,6 @@ package httpsig
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -164,25 +163,11 @@ func runTestSigBase(t *testing.T, tc testcaseSigBase) {
 	}
 
 	actualBase, err := calculateSignatureBase(hrr, tc.Params)
-	if err == nil && tc.ExpectedErr != "" {
-		t.Fatalf("Expected: error code '%s'. Got no error", tc.ExpectedErr)
-	}
-
-	if err != nil {
-		if tc.ExpectedErr == "" {
-			// The error was not expected
-			t.Fatal(err)
-		} else {
-			// Error expected. Ensure its the right kind of error
-			var se *SignatureError
-			if errors.As(err, &se) {
-				sigtest.Diff(t, tc.ExpectedErr, se.Code, "Unexpected error code")
-				return
-			} else {
-				// Only SignatureError is expected
-				t.Fatal(err)
-			}
-		}
+	if sigtest.Diff(t, tc.ExpectedErr, errCode(err), "Wrong error code") {
+		return
+	} else if tc.ExpectedErr != "" {
+		// If an error is expected and the err Diff check has passed then don't continue on to test the result
+		return
 	}
 
 	t.Log(string(actualBase.base))


### PR DESCRIPTION
This adds logic for parsing an Accept-Signature value according to the RFC.

Support for adding Accept-Signatures to requests or responses is not yet added.