### PR TITLE
Add a context parameter to the KeyFetcher interface methods

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,1 @@
+testdata/*.key

--- a/base.go
+++ b/base.go
@@ -1,6 +1,7 @@
 package httpsig
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -44,6 +45,13 @@ func (hrr httpMessage) SetBody(body io.ReadCloser) {
 		return
 	}
 	hrr.Req.Body = body
+}
+
+func (hrr httpMessage) Context() context.Context {
+	if hrr.IsResponse {
+		return context.Background()
+	}
+	return hrr.Req.Context()
 }
 
 /*

--- a/examples_test.go
+++ b/examples_test.go
@@ -57,7 +57,7 @@ func ExampleNewHandler() {
 	myhandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Lookup the results of verification
 		if veriftyResult, ok := httpsig.GetVerifyResult(r.Context()); ok {
-			keyid, _ := veriftyResult.Signature().Metadata.KeyID()
+			keyid, _ := veriftyResult.Signature().KeyID()
 			fmt.Fprintf(w, "Hello, %s", keyid)
 		} else {
 			fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))

--- a/keyman/keyman.go
+++ b/keyman/keyman.go
@@ -30,5 +30,5 @@ func (kf *KeyFetchInMemory) FetchByKeyID(ctx context.Context, rh http.Header, ke
 }
 
 func (kf *KeyFetchInMemory) Fetch(context.Context, http.Header, httpsig.MetadataProvider) (httpsig.KeySpecer, error) {
-	return httpsig.KeySpec{}, fmt.Errorf("Fetch without keyid not supported")
+	return nil, fmt.Errorf("Fetch without keyid not supported")
 }

--- a/keyman/keyman.go
+++ b/keyman/keyman.go
@@ -21,14 +21,14 @@ func NewKeyFetchInMemory(pubkeys map[string]httpsig.KeySpec) *KeyFetchInMemory {
 	return &KeyFetchInMemory{pubkeys}
 }
 
-func (kf *KeyFetchInMemory) FetchByKeyID(ctx context.Context, keyID string) (httpsig.KeySpec, error) {
+func (kf *KeyFetchInMemory) FetchByKeyID(ctx context.Context, rh http.Header, keyID string) (httpsig.KeySpecer, error) {
 	ks, found := kf.pubkeys[keyID]
 	if !found {
-		return httpsig.KeySpec{}, fmt.Errorf("Key for keyid '%s' not found", keyID)
+		return nil, fmt.Errorf("Key for keyid '%s' not found", keyID)
 	}
 	return ks, nil
 }
 
-func (kf *KeyFetchInMemory) Fetch(context.Context, http.Header, httpsig.MetadataProvider) (httpsig.KeySpec, error) {
+func (kf *KeyFetchInMemory) Fetch(context.Context, http.Header, httpsig.MetadataProvider) (httpsig.KeySpecer, error) {
 	return httpsig.KeySpec{}, fmt.Errorf("Fetch without keyid not supported")
 }

--- a/keyman/keyman.go
+++ b/keyman/keyman.go
@@ -2,6 +2,7 @@
 package keyman
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 
@@ -14,10 +15,13 @@ type KeyFetchInMemory struct {
 }
 
 func NewKeyFetchInMemory(pubkeys map[string]httpsig.KeySpec) *KeyFetchInMemory {
+	if pubkeys == nil {
+		pubkeys = map[string]httpsig.KeySpec{}
+	}
 	return &KeyFetchInMemory{pubkeys}
 }
 
-func (kf *KeyFetchInMemory) FetchByKeyID(keyID string) (httpsig.KeySpec, error) {
+func (kf *KeyFetchInMemory) FetchByKeyID(ctx context.Context, keyID string) (httpsig.KeySpec, error) {
 	ks, found := kf.pubkeys[keyID]
 	if !found {
 		return httpsig.KeySpec{}, fmt.Errorf("Key for keyid '%s' not found", keyID)
@@ -25,6 +29,6 @@ func (kf *KeyFetchInMemory) FetchByKeyID(keyID string) (httpsig.KeySpec, error) 
 	return ks, nil
 }
 
-func (kf *KeyFetchInMemory) Fetch(http.Header, httpsig.MetadataProvider) (httpsig.KeySpec, error) {
+func (kf *KeyFetchInMemory) Fetch(context.Context, http.Header, httpsig.MetadataProvider) (httpsig.KeySpec, error) {
 	return httpsig.KeySpec{}, fmt.Errorf("Fetch without keyid not supported")
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -281,17 +281,17 @@ type fixedKeyFetch struct {
 	key           KeySpec
 }
 
-func (kf fixedKeyFetch) FetchByKeyID(ctx context.Context, keyID string) (KeySpec, error) {
+func (kf fixedKeyFetch) FetchByKeyID(ctx context.Context, rh http.Header, keyID string) (KeySpecer, error) {
 	if kf.requiredKeyID != "" && keyID != kf.requiredKeyID {
-		return KeySpec{}, &KeyError{
+		return nil, &KeyError{
 			error: fmt.Errorf("Invalid key id. Wanted '%s' got '%s'", kf.requiredKeyID, keyID),
 		}
 	}
 	return kf.key, nil
 }
 
-func (kf fixedKeyFetch) Fetch(ctx context.Context, rh http.Header, md MetadataProvider) (KeySpec, error) {
-	return KeySpec{}, fmt.Errorf("Fetch without a key id not supported.")
+func (kf fixedKeyFetch) Fetch(ctx context.Context, rh http.Header, md MetadataProvider) (KeySpecer, error) {
+	return nil, fmt.Errorf("Fetch without a key id not supported.")
 }
 
 // TestSpecRecreateSignature recreates the signature in the test cases.

--- a/spec_test.go
+++ b/spec_test.go
@@ -2,6 +2,7 @@ package httpsig
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -280,7 +281,7 @@ type fixedKeyFetch struct {
 	key           KeySpec
 }
 
-func (kf fixedKeyFetch) FetchByKeyID(keyID string) (KeySpec, error) {
+func (kf fixedKeyFetch) FetchByKeyID(ctx context.Context, keyID string) (KeySpec, error) {
 	if kf.requiredKeyID != "" && keyID != kf.requiredKeyID {
 		return KeySpec{}, &KeyError{
 			error: fmt.Errorf("Invalid key id. Wanted '%s' got '%s'", kf.requiredKeyID, keyID),
@@ -289,7 +290,7 @@ func (kf fixedKeyFetch) FetchByKeyID(keyID string) (KeySpec, error) {
 	return kf.key, nil
 }
 
-func (kf fixedKeyFetch) Fetch(rh http.Header, md MetadataProvider) (KeySpec, error) {
+func (kf fixedKeyFetch) Fetch(ctx context.Context, rh http.Header, md MetadataProvider) (KeySpec, error) {
 	return KeySpec{}, fmt.Errorf("Fetch without a key id not supported.")
 }
 

--- a/verify.go
+++ b/verify.go
@@ -145,9 +145,6 @@ type Verifier struct {
 
 // Verify validates the signatures in a request and ensured the signature meets the required profile.
 func Verify(req *http.Request, kf KeyFetcher, profile VerifyProfile) (VerifyResult, error) {
-	if kf == nil {
-		return VerifyResult{}, newError(ErrSigKeyFetch, "KeyFetcher cannot be nil")
-	}
 	ver, err := NewVerifier(kf, profile)
 	if err != nil {
 		return VerifyResult{}, err
@@ -164,6 +161,9 @@ func VerifyResponse(resp *http.Response, kf KeyFetcher, profile VerifyProfile) (
 }
 
 func NewVerifier(kf KeyFetcher, profile VerifyProfile) (*Verifier, error) {
+	if kf == nil {
+		return nil, newError(ErrSigKeyFetch, "KeyFetcher cannot be nil")
+	}
 	return &Verifier{
 		keys: kf,
 	}, nil
@@ -387,6 +387,7 @@ func (ver *Verifier) verifySignature(r httpMessage, sig extractedSignature) (Key
 		if err != nil {
 			return nil, newError(ErrSigKeyFetch, "Could not get keyid from signature metadata", err)
 		}
+
 		specer, err = ver.keys.FetchByKeyID(r.Context(), r.Headers(), keyid)
 		if err != nil {
 			return nil, newError(ErrSigKeyFetch, fmt.Sprintf("Failed to fetch key for keyid '%s'", keyid), err)

--- a/verify_test.go
+++ b/verify_test.go
@@ -32,7 +32,7 @@ func TestVerify(t *testing.T) {
 				Signatures: map[string]httpsig.VerifiedSignature{
 					"sig-b21": {
 						Label: "sig-b21",
-						Metadata: &fixedMetadataProvider{map[httpsig.Metadata]any{
+						MetadataProvider: &fixedMetadataProvider{map[httpsig.Metadata]any{
 							httpsig.MetaKeyID:   "test-key-rsa-pss",
 							httpsig.MetaCreated: int64(1618884473),
 							httpsig.MetaNonce:   "b3k2pp5k7z-50gnwp.yemd",
@@ -77,7 +77,7 @@ func TestVerifyInvalid(t *testing.T) {
 				Signatures: map[string]httpsig.VerifiedSignature{
 					"sig-b21": {
 						Label: "sig-b21",
-						Metadata: &fixedMetadataProvider{map[httpsig.Metadata]any{
+						MetadataProvider: &fixedMetadataProvider{map[httpsig.Metadata]any{
 							httpsig.MetaKeyID:   "test-key-rsa-pss",
 							httpsig.MetaCreated: int64(1618884473),
 							httpsig.MetaNonce:   "b3k2pp5k7z-50gnwp.yemd",
@@ -109,7 +109,7 @@ func TestVerifyInvalid(t *testing.T) {
 				Signatures: map[string]httpsig.VerifiedSignature{
 					"sig-b21": {
 						Label: "sig-b21",
-						Metadata: &fixedMetadataProvider{map[httpsig.Metadata]any{
+						MetadataProvider: &fixedMetadataProvider{map[httpsig.Metadata]any{
 							httpsig.MetaKeyID:   "test-key-rsa-pss",
 							httpsig.MetaCreated: int64(1618884473),
 							httpsig.MetaNonce:   "b3k2pp5k7z-50gnwp.yemd",
@@ -198,7 +198,6 @@ func metaVal[E comparable](f1 func() (E, error)) any {
 func getCmdOpts() []cmp.Option {
 	return []cmp.Option{
 		cmp.Transformer("Metadata", TransformMeta),
-		cmp.Transformer("InvalidSignature", TransformInvalidSig),
 	}
 
 }
@@ -214,23 +213,10 @@ func TransformMeta(md httpsig.MetadataProvider) map[string]any {
 	return out
 }
 
-func TransformInvalidSig(isig httpsig.InvalidSignature) map[string]any {
-
-	out := map[string]any{
-		"Label":       isig.Label,
-		"Raw":         isig.Raw,
-		"Error":       isig.Raw,
-		"HasMetadata": isig.HasMetadata,
-	}
-	if md, ok := isig.Metadata(); ok {
-		out["Metadata"] = TransformMeta(md)
-	}
-
-	return out
-}
-
 func createInvalidSignature(input httpsig.InvalidSignature, md httpsig.MetadataProvider) httpsig.InvalidSignature {
-	is := httpsig.NewInvalidSignature(md)
+	is := httpsig.InvalidSignature{
+		MetadataProvider: md,
+	}
 	is.Error = input.Error
 	is.HasMetadata = input.HasMetadata
 	is.Label = input.Label


### PR DESCRIPTION
The primary change is to the KeyFetcher interface. 

Instead of returning a concrete KeySpec it now returns KeySpecer which is an interface with a method to return the KeySpec.

This allows this library to add a KeySpecer to the VerifyResult struct.  This allows callers to then retrieve their concrete Credential/Key struct with a type assertion. Before this change the caller was required to lookup their credential again by the KeyID.

Smaller change to add the context.Context parameter to KeyFetcher calls.