### PR TITLE
Better separate SigningProfile form SigningKey

### DIFF
--- a/accept_test.go
+++ b/accept_test.go
@@ -11,19 +11,21 @@ func TestAcceptParseSignature(t *testing.T) {
 		Name            string
 		Desc            string
 		AcceptHeader    string
-		Expected        SigningProfile
+		Expected        AcceptSignature
 		ExpectedErrCode ErrCode
 	}{
 		{
 			Name:         "FromSpecification",
 			Desc:         "Accept header used in the RFC",
 			AcceptHeader: `sig1=("@method" "@target-uri" "@authority" "content-digest" "cache-control");keyid="test-key-rsa-pss";created;tag="app-123"`,
-			Expected: SigningProfile{
-				Fields:    Fields("@method", "@target-uri", "@authority", "content-digest", "cache-control"),
-				Metadata:  []Metadata{"keyid", "created", "tag"},
-				Label:     "sig1",
+			Expected: AcceptSignature{
 				MetaKeyID: "test-key-rsa-pss",
 				MetaTag:   "app-123",
+				Profile: SigningProfile{
+					Fields:   Fields("@method", "@target-uri", "@authority", "content-digest", "cache-control"),
+					Metadata: []Metadata{"keyid", "created", "tag"},
+					Label:    "sig1",
+				},
 			},
 		},
 		{

--- a/examples_test.go
+++ b/examples_test.go
@@ -22,14 +22,17 @@ BznPJ5sSI1Jn+srosJB/GbEZ3Kg6PcEi+jODF9fdpNEaHGbbGdaVhJi1
 	pkey, _ := keyutil.ReadPrivateKey([]byte(pkeyEncoded))
 	req := httptest.NewRequest("GET", "https://example.com/data", nil)
 
-	params := httpsig.SigningProfile{
+	profile := httpsig.SigningProfile{
 		Algorithm: httpsig.Algo_ECDSA_P256_SHA256,
 		Fields:    httpsig.DefaultRequiredFields,
 		Metadata:  []httpsig.Metadata{httpsig.MetaKeyID},
+	}
+	skey := httpsig.SigningKey{
+		Key:       pkey,
 		MetaKeyID: "key123",
 	}
 
-	signer, _ := httpsig.NewSigner(params, pkey)
+	signer, _ := httpsig.NewSigner(profile, skey)
 	signer.Sign(req)
 }
 
@@ -73,16 +76,19 @@ func ExampleNewHandler() {
 }
 
 func ExampleClient() {
-	params := httpsig.SigningProfile{
+	profile := httpsig.SigningProfile{
 		Algorithm: httpsig.Algo_ECDSA_P256_SHA256,
 		Fields:    httpsig.DefaultRequiredFields,
 		Metadata:  []httpsig.Metadata{httpsig.MetaKeyID},
-		MetaKeyID: "key123",
 	}
 	var privateKey crypto.PrivateKey // Get your private key
 
+	sk := httpsig.SigningKey{
+		Key:       privateKey,
+		MetaKeyID: "key123",
+	}
 	// Create the signature signer
-	signer, _ := httpsig.NewSigner(params, privateKey)
+	signer, _ := httpsig.NewSigner(profile, sk)
 
 	// Create a net/http Client that signs all requests
 	signingClient := httpsig.NewHTTPClient(nil, signer, nil)

--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -16,8 +16,9 @@ func TestRoundTrip(t *testing.T) {
 	testcases := []struct {
 		Name                  string
 		PrivateKey            crypto.PrivateKey
+		MetaKeyID             string
 		Secret                []byte
-		Params                httpsig.SigningProfile
+		SignProfile           httpsig.SigningProfile
 		RequestFile           string
 		Keys                  httpsig.KeyFetcher
 		Profile               httpsig.VerifyProfile
@@ -26,12 +27,12 @@ func TestRoundTrip(t *testing.T) {
 		{
 			Name:       "RSA-PSS",
 			PrivateKey: keyutil.MustReadPrivateKeyFile("testdata/test-key-rsa-pss.key"),
-			Params: httpsig.SigningProfile{
+			MetaKeyID:  "test-key-rsa",
+			SignProfile: httpsig.SigningProfile{
 				Algorithm: httpsig.Algo_RSA_PSS_SHA512,
 				Fields:    httpsig.DefaultRequiredFields,
 				Metadata:  []httpsig.Metadata{httpsig.MetaCreated, httpsig.MetaKeyID},
 				Label:     "tst-rsa-pss",
-				MetaKeyID: "test-key-rsa",
 			},
 			RequestFile: "rfc-test-request.txt",
 			Keys: keyman.NewKeyFetchInMemory(map[string]httpsig.KeySpec{
@@ -46,12 +47,12 @@ func TestRoundTrip(t *testing.T) {
 		{
 			Name:       "RSA-v15",
 			PrivateKey: keyutil.MustReadPrivateKeyFile("testdata/key-rsa-v15.key"),
-			Params: httpsig.SigningProfile{
+			MetaKeyID:  "test-key-rsa",
+			SignProfile: httpsig.SigningProfile{
 				Algorithm: httpsig.Algo_RSA_v1_5_sha256,
 				Fields:    httpsig.DefaultRequiredFields,
 				Metadata:  []httpsig.Metadata{httpsig.MetaCreated, httpsig.MetaKeyID},
 				Label:     "tst-rsa-pss",
-				MetaKeyID: "test-key-rsa",
 			},
 			RequestFile: "rfc-test-request.txt",
 			Keys: keyman.NewKeyFetchInMemory(map[string]httpsig.KeySpec{
@@ -64,13 +65,13 @@ func TestRoundTrip(t *testing.T) {
 			Profile: httpsig.DefaultVerifyProfile,
 		},
 		{
-			Name:   "HMAC_SHA256",
-			Secret: sigtest.MustReadFile("testdata/test-shared-secret"),
-			Params: httpsig.SigningProfile{
+			Name:      "HMAC_SHA256",
+			Secret:    sigtest.MustReadFile("testdata/test-shared-secret"),
+			MetaKeyID: "test-key-shared",
+			SignProfile: httpsig.SigningProfile{
 				Algorithm: httpsig.Algo_HMAC_SHA256,
 				Fields:    httpsig.DefaultRequiredFields,
 				Metadata:  []httpsig.Metadata{httpsig.MetaCreated, httpsig.MetaKeyID},
-				MetaKeyID: "test-key-shared",
 			},
 			RequestFile: "rfc-test-request.txt",
 			Keys: keyman.NewKeyFetchInMemory(map[string]httpsig.KeySpec{
@@ -85,12 +86,12 @@ func TestRoundTrip(t *testing.T) {
 		{
 			Name:       "ECDSA-p265",
 			PrivateKey: keyutil.MustReadPrivateKeyFile("testdata/test-key-ecc-p256.key"),
-			Params: httpsig.SigningProfile{
+			MetaKeyID:  "test-key-ecdsa",
+			SignProfile: httpsig.SigningProfile{
 				Algorithm: httpsig.Algo_ECDSA_P256_SHA256,
 				Fields:    httpsig.DefaultRequiredFields,
 				Metadata:  []httpsig.Metadata{httpsig.MetaCreated, httpsig.MetaKeyID},
 				Label:     "tst-ecdsa",
-				MetaKeyID: "test-key-ecdsa",
 			},
 			RequestFile: "rfc-test-request.txt",
 			Keys: keyman.NewKeyFetchInMemory(map[string]httpsig.KeySpec{
@@ -105,12 +106,12 @@ func TestRoundTrip(t *testing.T) {
 		{
 			Name:       "ECDSA-p384",
 			PrivateKey: keyutil.MustReadPrivateKeyFile("testdata/test-key-ecc-p384.key"),
-			Params: httpsig.SigningProfile{
+			MetaKeyID:  "test-key-ecdsa",
+			SignProfile: httpsig.SigningProfile{
 				Algorithm: httpsig.Algo_ECDSA_P384_SHA384,
 				Fields:    httpsig.DefaultRequiredFields,
 				Metadata:  []httpsig.Metadata{httpsig.MetaCreated, httpsig.MetaKeyID},
 				Label:     "tst-ecdsa",
-				MetaKeyID: "test-key-ecdsa",
 			},
 			RequestFile: "rfc-test-request.txt",
 			Keys: keyman.NewKeyFetchInMemory(map[string]httpsig.KeySpec{
@@ -125,12 +126,12 @@ func TestRoundTrip(t *testing.T) {
 		{
 			Name:       "ED25519",
 			PrivateKey: keyutil.MustReadPrivateKeyFile("testdata/test-key-ed25519.key"),
-			Params: httpsig.SigningProfile{
+			MetaKeyID:  "test-key-ed",
+			SignProfile: httpsig.SigningProfile{
 				Algorithm: httpsig.Algo_ED25519,
 				Fields:    httpsig.DefaultRequiredFields,
 				Metadata:  []httpsig.Metadata{httpsig.MetaCreated, httpsig.MetaKeyID},
 				Label:     "tst-ed",
-				MetaKeyID: "test-key-ed",
 			},
 			RequestFile: "rfc-test-request.txt",
 			Keys: keyman.NewKeyFetchInMemory(map[string]httpsig.KeySpec{
@@ -145,13 +146,13 @@ func TestRoundTrip(t *testing.T) {
 		{
 			Name:       "BadDigest",
 			PrivateKey: keyutil.MustReadPrivateKeyFile("testdata/test-key-ed25519.key"),
-			Params: httpsig.SigningProfile{
+			MetaKeyID:  "test-key-ed",
+			SignProfile: httpsig.SigningProfile{
 
 				Algorithm: httpsig.Algo_ED25519,
 				Fields:    httpsig.DefaultRequiredFields,
 				Metadata:  []httpsig.Metadata{httpsig.MetaCreated, httpsig.MetaKeyID},
 				Label:     "tst-content-digest",
-				MetaKeyID: "test-key-ed",
 			},
 			RequestFile: "request_bad_digest.txt",
 			Keys: keyman.NewKeyFetchInMemory(map[string]httpsig.KeySpec{
@@ -169,22 +170,19 @@ func TestRoundTrip(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
 			var signer *httpsig.Signer
-			if isSymmetric(tc.Params.Algorithm) {
-				var err error
-				signer, err = httpsig.NewSignerWithSecret(tc.Params, tc.Secret)
-				if err != nil {
-					t.Fatal(err)
-				}
-			} else {
-				var err error
-				signer, err = httpsig.NewSigner(tc.Params, tc.PrivateKey)
-				if err != nil {
-					t.Fatal(err)
-				}
+			sk := httpsig.SigningKey{
+				Key:       tc.PrivateKey,
+				Secret:    tc.Secret,
+				MetaKeyID: tc.MetaKeyID,
+			}
+
+			signer, err := httpsig.NewSigner(tc.SignProfile, sk)
+			if err != nil {
+				t.Fatal(err)
 			}
 
 			req := sigtest.ReadRequest(t, tc.RequestFile)
-			err := signer.Sign(req)
+			err = signer.Sign(req)
 			if err != nil {
 				t.Fatalf("%#v", err)
 			}
@@ -210,12 +208,4 @@ func TestRoundTrip(t *testing.T) {
 		})
 
 	}
-}
-
-func isSymmetric(a httpsig.Algorithm) bool {
-	switch a {
-	case httpsig.Algo_HMAC_SHA256:
-		return true
-	}
-	return false
 }

--- a/signatures.go
+++ b/signatures.go
@@ -26,6 +26,16 @@ const (
 	authority derived = "@authority"
 )
 
+// MetadataProvider allows customized functions for metadata parameter values. Not needed for default usage.
+type MetadataProvider interface {
+	Created() (int, error)
+	Expires() (int, error)
+	Nonce() (string, error)
+	Alg() (string, error)
+	KeyID() (string, error)
+	Tag() (string, error)
+}
+
 type signatureBase struct {
 	base           []byte // The full signature base. Use this as input to signing and verification
 	signatureInput string // The signature-input line
@@ -129,8 +139,4 @@ func sign(hrr httpMessage, sp sigParameters) error {
 
 func timestamp(nowtime func() time.Time) int {
 	return int(nowtime().Unix())
-}
-
-func genNonce() string {
-	return ""
 }


### PR DESCRIPTION
This PR properly separates the SigningProfile from the SigningKey.  It's ultimately a small logical change but it required updates in several places to introduce the SigningKey concept.

SigningOptions/SingingProfile included things that are not specific the generic signing profile - the secret/private key to sign with and the KeyID for example.  These are specific to the key or secret used to sign but don't change the expected signature profile.

These are now separated.