### PR TITLE
Refactor verify to expect a named signature label and do single signa…

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -60,8 +60,8 @@ func ExampleNewHandler() {
 	myhandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Lookup the results of verification
 		if veriftyResult, ok := httpsig.GetVerifyResult(r.Context()); ok {
-			keyid, _ := veriftyResult.Signature().KeyID()
-			fmt.Fprintf(w, "Hello, %s", keyid)
+			keyid, _ := veriftyResult.KeyID()
+			fmt.Fprintf(w, "Hello, %s", html.EscapeString(keyid))
 		} else {
 			fmt.Fprintf(w, "Hello, %q", html.EscapeString(r.URL.Path))
 		}

--- a/fz_test.go
+++ b/fz_test.go
@@ -180,14 +180,21 @@ func FuzzExtractSignatures(f *testing.F) {
 
 		req.Header.Set("signature", sigHeader)
 		req.Header.Set("signature-input", sigInputHeader)
-		_, err = extractSignatures(req.Header)
+
+		sigSFV, err := parseSignaturesFromRequest(req.Header)
 		if err != nil {
-			if _, ok := err.(*SignatureError); ok {
-				// Handled error
-				return
+			return
+		}
+		for _, label := range sigSFV.Sigs.Names() {
+			_, err = unmarshalSignature(sigSFV, label)
+			if err != nil {
+				if _, ok := err.(*SignatureError); ok {
+					// Handled error
+					return
+				}
+				// Unhandled error
+				t.Error(err)
 			}
-			// Unhandled error
-			t.Error(err)
 		}
 	})
 }

--- a/keyutil/jwk.go
+++ b/keyutil/jwk.go
@@ -139,21 +139,20 @@ func (ob *octet) UnmarshalJSON(data []byte) error {
 	x.SetBytes(rawBytes)
 	*ob = octet{x}
 
-	fmt.Printf("Decoded string '%s' into '%d' bytes and bitlen '%d' and bytes '%d'\n", encoded, len(rawBytes), x.BitLen(), len(x.Bytes()))
 	return nil
 }
 
 type jwk struct {
-	KeyType string `json:"kty"`            // kty  algorithm family used with the key such as "RSA" or "EC".
+	KeyType string `json:"kty"`           // kty  algorithm family used with the key such as "RSA" or "EC".
 	Algo    string `json:"alg,omitempty"` // alg identifies the algorithm intended for use with the key.
 	KeyID   string `json:"kid,omitempty"` // Used to match a specific key
 }
 
 type jwkEC struct {
 	jwk
-	Curve string `json:"crv"`          // The curve used with the key e.g. P-256
-	X     octet  `json:"x"`            // x coordinate of the curve.
-	Y     octet  `json:"y"`            // y coordinate of the curve.
+	Curve string `json:"crv"`         // The curve used with the key e.g. P-256
+	X     octet  `json:"x"`           // x coordinate of the curve.
+	Y     octet  `json:"y"`           // y coordinate of the curve.
 	D     octet  `json:"d,omitempty"` // For private keys.
 }
 

--- a/spec_test.go
+++ b/spec_test.go
@@ -95,7 +95,9 @@ func TestSpecVerify(t *testing.T) {
 			ver, err := NewVerifier(&fixedKeyFetch{
 				requiredKeyID: tc.Key.KeyID,
 				key:           tc.Key,
-			}, VerifyProfile{})
+			}, VerifyProfile{
+				SignatureLabel: fmt.Sprintf("sig-%s", tc.Name),
+			})
 
 			var verifyErr error
 			if tc.IsResponse {


### PR DESCRIPTION
Refactor verify to expect a named signature label and do single signature verification.

Part of verification I missed was needing to know which signature to verify.  This should be statically known ahead of time.
One example from Amazon is here - https://developer-docs.amazon.com/sp-api/docs/tpp-registration-signature-guidance

This ends up simplifying the verify code quite a bit.