### PR TITLE
Fix HTTP response writing order.

### DIFF
--- a/http.go
+++ b/http.go
@@ -55,8 +55,8 @@ func (vh VerifyHandler) ServeHTTP(rw http.ResponseWriter, inReq *http.Request) {
 	vr, err := vh.verifier.Verify(inReq)
 	if err != nil {
 		// Failed to verify
-		rw.Write([]byte("Unauthorized"))
 		rw.WriteHeader(http.StatusUnauthorized)
+		rw.Write([]byte("Unauthorized"))
 		return
 	}
 


### PR DESCRIPTION
In the original code, calling `Write` first implicitly calls `WriteHeader(http.StatusOK)` if `WriteHeader` hasn’t been called yet. So the HTTP status will always end up being `200 OK`