### PR TITLE
Fix P-521 coordinate length calculation

### DIFF
--- a/keyutil/jwk.go
+++ b/keyutil/jwk.go
@@ -198,7 +198,7 @@ func (ec *jwkEC) params() (crv elliptic.Curve, byteLen int, e error) {
 	default:
 		return nil, 0, fmt.Errorf("Unsupported ECC curve '%s'", ec.Curve)
 	}
-	return crv, crv.Params().BitSize / 8, nil
+	return crv, (crv.Params().BitSize + 7) / 8, nil
 }
 
 func (ec *jwkEC) PublicKey() (*ecdsa.PublicKey, error) {


### PR DESCRIPTION
The P-521 curve has 521 bits (65.125 bytes), but JWK EC coordinates must be zero-padded to 66 bytes. Using `crv.Params().BitSize/8` truncates to 65 bytes. Updating the calculation to round up. We need 66 bytes to store 521 bits.