### PR TITLE
Initial validate logic and tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,23 +36,28 @@ This is an implementation of HTTP Message Signatures per RFC 9421. The library p
    - `SigningKey` holds cryptographic material and metadata
    - Supports asymmetric (RSA, ECDSA, Ed25519) and symmetric (HMAC) algorithms
 
-2. **Verification Pipeline** (`verify.go`)
+2. **Accept-Signature Support** (`accept.go`)
+   - `AcceptSignature` struct for parsing Accept-Signature headers
+   - `ParseAcceptSignature()` function for client-server signature negotiation
+   - Support for signature profile requirements from clients
+
+3. **Verification Pipeline** (`verify.go`)
    - `Verifier` struct handles signature verification
    - `VerifyProfile` enforces security requirements beyond basic signature validation
    - `KeyFetcher` interface for key retrieval by keyID or other metadata
-   - Time-based validation for created/expires metadata
+   - Time-based validation for created/expires metadata with configurable tolerances
 
-3. **Core Engine** (`base.go`)
+4. **Core Engine** (`base.go`)
    - `calculateSignatureBase()` generates the canonical string for signing/verification
    - `componentID` represents signature components (headers or derived values like @method, @target-uri)
    - `httpMessage` abstraction handles both requests and responses uniformly
 
-4. **HTTP Integration** (`http.go`)
+5. **HTTP Integration** (`http.go`)
    - `NewHTTPClient()` creates signing/verifying HTTP clients
    - `NewHandler()` wraps http.Handler for automatic request verification
    - `transport` type implements http.RoundTripper for transparent signing/verification
 
-5. **Content Integrity** (`digest.go`)
+6. **Content Integrity** (`digest.go`)
    - Automatic Content-Digest header calculation when signing
    - Support for SHA-256 and SHA-512 digests
    - Body preservation during digest calculation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,109 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is an implementation of HTTP Message Signatures per RFC 9421. The library provides functionality for signing and verifying HTTP requests and responses using various cryptographic algorithms.
+
+## Development Commands
+
+### Testing
+- `go test` - Run all tests
+- `go test ./...` - Run tests recursively for all packages
+- `go test -v` - Run tests with verbose output
+- `go test -run TestName` - Run specific test
+- `go test -fuzz FuzzName` - Run fuzz tests (see testdata/fuzz/ for existing fuzz test data)
+
+### Building and Linting
+- `go build` - Build the package
+- `go vet` - Run go vet for static analysis
+- `go fmt ./...` - Format all Go files
+- `go mod tidy` - Clean up module dependencies
+- `go mod verify` - Verify module integrity
+
+### Coverage
+- `go test -cover` - Run tests with coverage
+- `go test -coverprofile=coverage.out && go tool cover -html=coverage.out` - Generate HTML coverage report
+
+## Architecture Overview
+
+### Core Components
+
+1. **Signing Pipeline** (`sign.go`, `signatures.go`)
+   - `Signer` struct orchestrates request/response signing
+   - `SigningProfile` defines what fields and metadata to include
+   - `SigningKey` holds cryptographic material and metadata
+   - Supports asymmetric (RSA, ECDSA, Ed25519) and symmetric (HMAC) algorithms
+
+2. **Verification Pipeline** (`verify.go`)
+   - `Verifier` struct handles signature verification
+   - `VerifyProfile` enforces security requirements beyond basic signature validation
+   - `KeyFetcher` interface for key retrieval by keyID or other metadata
+   - Time-based validation for created/expires metadata
+
+3. **Core Engine** (`base.go`)
+   - `calculateSignatureBase()` generates the canonical string for signing/verification
+   - `componentID` represents signature components (headers or derived values like @method, @target-uri)
+   - `httpMessage` abstraction handles both requests and responses uniformly
+
+4. **HTTP Integration** (`http.go`)
+   - `NewHTTPClient()` creates signing/verifying HTTP clients
+   - `NewHandler()` wraps http.Handler for automatic request verification
+   - `transport` type implements http.RoundTripper for transparent signing/verification
+
+5. **Content Integrity** (`digest.go`)
+   - Automatic Content-Digest header calculation when signing
+   - Support for SHA-256 and SHA-512 digests
+   - Body preservation during digest calculation
+
+### Key Utilities
+
+- **keyman/** - In-memory key storage implementation
+- **keyutil/** - PEM key file reading utilities with support for various formats
+- **sigtest/** - Test helpers for signature testing
+
+### Error Handling
+
+The library uses a structured error system (`sigerrors.go`) with specific error types:
+- `ErrNoSigMissingSignature` - Missing signature headers
+- `ErrSigVerification` - Signature verification failures
+- `ErrSigProfile` - Profile validation failures
+- `ErrSigKeyFetch` - Key retrieval failures
+
+### Algorithm Support
+
+**Asymmetric:**
+- RSA-PSS-SHA512 (`rsa-pss-sha512`)
+- RSA v1.5 SHA256 (`rsa-v1_5-sha256`)
+- ECDSA P-256 SHA256 (`ecdsa-p256-sha256`)
+- ECDSA P-384 SHA384 (`ecdsa-p384-sha384`)
+- Ed25519 (`ed25519`)
+
+**Symmetric:**
+- HMAC-SHA256 (`hmac-sha256`)
+
+### Security Defaults
+
+`DefaultVerifyProfile` provides secure defaults:
+- Requires Content-Digest, @method, @target-uri fields
+- Mandates 'created' and 'keyid' metadata
+- 5-minute signature validity window
+- Prohibits algorithm metadata (must be derived from key)
+- Allows only secure algorithms (ECDSA, Ed25519, HMAC)
+
+## Testing Approach
+
+The codebase uses standard Go testing with:
+- RFC test vectors in `testdata/` directory
+- Fuzz testing for signature parsing
+- Round-trip tests validating sign→verify cycles
+- Comprehensive algorithm coverage
+
+## Important Implementation Notes
+
+- Signature base calculation follows RFC 9421 exactly
+- Multi-value headers are not yet supported (will return error)
+- Content-Digest is automatically calculated when included in signature fields
+- Request body is preserved during signing/verification by reading and reconstructing
+- Context keys are used to pass verification results through HTTP middleware

--- a/roundtrip_test.go
+++ b/roundtrip_test.go
@@ -42,7 +42,10 @@ func TestRoundTrip(t *testing.T) {
 					PubKey: keyutil.MustReadPublicKeyFile("testdata/test-key-rsa-pss.pub"),
 				},
 			}),
-			Profile: createVerifyProfile("tst-rsa-pss"),
+			Profile: httpsig.VerifyProfile{
+				SignatureLabel:    "tst-rsa-pss",
+				AllowedAlgorithms: []httpsig.Algorithm{httpsig.Algo_RSA_PSS_SHA512},
+			},
 		},
 		{
 			Name:       "RSA-v15",
@@ -62,7 +65,10 @@ func TestRoundTrip(t *testing.T) {
 					PubKey: keyutil.MustReadPublicKeyFile("testdata/key-rsa-v15.pub"),
 				},
 			}),
-			Profile: createVerifyProfile("tst-rsa-pss"),
+			Profile: httpsig.VerifyProfile{
+				SignatureLabel:    "tst-rsa-pss",
+				AllowedAlgorithms: []httpsig.Algorithm{httpsig.Algo_RSA_v1_5_sha256},
+			},
 		},
 		{
 			Name:      "HMAC_SHA256",

--- a/spec_test.go
+++ b/spec_test.go
@@ -84,7 +84,7 @@ func TestSpecVerify(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			if tc.Skip {
-				t.Skip(fmt.Sprintf("Skipping test %s", tc.Name))
+				t.Skipf("Skipping test %s", tc.Name)
 			}
 
 			hrrtxt, err := os.Open(fmt.Sprintf("testdata/%s", tc.SignedRequestOrResonseFile))

--- a/spec_test.go
+++ b/spec_test.go
@@ -96,7 +96,8 @@ func TestSpecVerify(t *testing.T) {
 				requiredKeyID: tc.Key.KeyID,
 				key:           tc.Key,
 			}, VerifyProfile{
-				SignatureLabel: fmt.Sprintf("sig-%s", tc.Name),
+				SignatureLabel:         fmt.Sprintf("sig-%s", tc.Name),
+				DisableTimeEnforcement: true,
 			})
 
 			var verifyErr error

--- a/validate_test.go
+++ b/validate_test.go
@@ -39,6 +39,9 @@ func TestValidateProfile(t *testing.T) {
 				AllowedAlgorithms: []Algorithm{Algo_ECDSA_P256_SHA256},
 				RequiredFields:    Fields("content-digest", "@method", "@target-uri"),
 				RequiredMetadata:  []Metadata{MetaCreated, MetaKeyID},
+				nowTime: func() time.Time {
+					return time.Unix(int64(1755206251), 0)
+				},
 			},
 			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
 			Expected:    ErrCode(""),
@@ -234,6 +237,9 @@ func TestValidateProfile(t *testing.T) {
 			},
 			Profile: VerifyProfile{
 				RequiredMetadata: []Metadata{MetaCreated, MetaKeyID},
+				nowTime: func() time.Time {
+					return time.Unix(int64(1755206251), 0)
+				},
 			},
 			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
 			Expected:    ErrCode(""),
@@ -291,6 +297,9 @@ func TestValidateProfile(t *testing.T) {
 			},
 			Profile: VerifyProfile{
 				DisallowedMetadata: []Metadata{MetaAlgorithm},
+				nowTime: func() time.Time {
+					return time.Unix(int64(1755206251), 0)
+				},
 			},
 			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
 			Expected:    ErrCode(""),
@@ -322,6 +331,9 @@ func TestValidateProfile(t *testing.T) {
 				RequiredFields:     Fields("content-digest", "@method", "@target-uri"),
 				RequiredMetadata:   []Metadata{MetaCreated, MetaKeyID},
 				DisallowedMetadata: []Metadata{MetaAlgorithm},
+				nowTime: func() time.Time {
+					return time.Unix(int64(1755206251), 0)
+				},
 			},
 			KeySpecAlgo: Algo_ED25519,
 			Expected:    ErrCode(""),
@@ -367,7 +379,7 @@ func TestValidateProfile(t *testing.T) {
 					MetadataParams: []Metadata{MetaCreated, MetaKeyID},
 					MetadataValues: fixedMetadataProvider{
 						values: map[Metadata]any{
-							MetaCreated: int64(1755206251),
+							MetaCreated: time.Now().Unix(),
 						},
 					},
 				},
@@ -617,27 +629,6 @@ func TestValidateTiming(t *testing.T) {
 			},
 			Expected: ErrCode(""), // Should be allowed due to clock skew tolerance
 		},
-		{
-			Name: "NoCreatedValidDuration_NoTimeLimit",
-			Sig: extractedSignature{
-				Label:     "sig1",
-				Signature: []byte{},
-				Input: sigBaseInput{
-					Components:     []componentID{},
-					MetadataParams: []Metadata{MetaCreated},
-					MetadataValues: fixedMetadataProvider{
-						values: map[Metadata]any{
-							MetaCreated: int64(now.Add(-24 * time.Hour).Unix()), // 24 hours ago
-						},
-					},
-				},
-			},
-			Profile: VerifyProfile{
-				CreatedValidDuration: 0, // No duration limit
-			},
-			Expected: ErrCode(""), // Should be allowed
-		},
-
 		// Expires Time Validation Tests
 		{
 			Name: "ValidExpiresTime",

--- a/validate_test.go
+++ b/validate_test.go
@@ -1,0 +1,922 @@
+package httpsig
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/remitly-oss/httpsig-go/sigtest"
+)
+
+// Test helper for creating metadata providers with fixed values
+type testMetadataProvider struct {
+	values map[Metadata]any
+}
+
+func (tmp testMetadataProvider) Created() (int, error) {
+	if val, ok := tmp.values[MetaCreated]; ok {
+		return int(val.(int64)), nil
+	}
+	return 0, fmt.Errorf("No created value")
+}
+
+func (tmp testMetadataProvider) Expires() (int, error) {
+	if val, ok := tmp.values[MetaExpires]; ok {
+		return int(val.(int64)), nil
+	}
+	return 0, fmt.Errorf("No expires value")
+}
+
+func (tmp testMetadataProvider) Nonce() (string, error) {
+	if val, ok := tmp.values[MetaNonce]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("No nonce value")
+}
+
+func (tmp testMetadataProvider) Alg() (string, error) {
+	if val, ok := tmp.values[MetaAlgorithm]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("No alg value")
+}
+
+func (tmp testMetadataProvider) KeyID() (string, error) {
+	if val, ok := tmp.values[MetaKeyID]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("No keyid value")
+}
+
+func (tmp testMetadataProvider) Tag() (string, error) {
+	if val, ok := tmp.values[MetaTag]; ok {
+		return val.(string), nil
+	}
+	return "", fmt.Errorf("No tag value")
+}
+
+func TestValidateProfile(t *testing.T) {
+	testcases := []struct {
+		Name        string
+		Sig         extractedSignature
+		Profile     VerifyProfile
+		KeySpecAlgo Algorithm
+		Expected    ErrCode // Expected ErrCode if an error. Empty string if expecting no error
+		ExpectedMsg string
+	}{
+		// Signature Label Validation Tests
+		{
+			Name: "ValidSignatureLabel",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{{Name: "content-digest"}, {Name: "@method"}, {Name: "@target-uri"}},
+					MetadataParams: []Metadata{MetaCreated, MetaKeyID},
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				SignatureLabel:    "sig1",
+				AllowedAlgorithms: []Algorithm{Algo_ECDSA_P256_SHA256},
+				RequiredFields:    Fields("content-digest", "@method", "@target-uri"),
+				RequiredMetadata:  []Metadata{MetaCreated, MetaKeyID},
+			},
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrCode(""),
+		},
+		{
+			Name: "InvalidSignatureLabel",
+			Sig: extractedSignature{
+				Label:     "sig2",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{},
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				SignatureLabel: "sig1",
+			},
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Signature label 'sig2' does not match required label 'sig1'",
+		},
+		{
+			Name: "EmptySignatureLabelInProfile",
+			Sig: extractedSignature{
+				Label:     "sig2",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{},
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				SignatureLabel: "", // Empty means any label is acceptable
+			},
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrCode(""),
+		},
+
+		// Algorithm Validation Tests
+		{
+			Name: "ValidAlgorithm",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{},
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				AllowedAlgorithms: []Algorithm{Algo_ECDSA_P256_SHA256, Algo_ED25519},
+			},
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrCode(""),
+		},
+		{
+			Name: "InvalidAlgorithm",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{},
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				AllowedAlgorithms: []Algorithm{Algo_ECDSA_P256_SHA256, Algo_ED25519},
+			},
+			KeySpecAlgo: Algo_RSA_PSS_SHA512,
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Algorithm 'rsa-pss-sha512' is not in allowed algorithms list",
+		},
+		{
+			Name: "NoAllowedAlgorithmsRestriction",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{},
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				AllowedAlgorithms: []Algorithm{}, // Empty means any algorithm is acceptable
+			},
+			KeySpecAlgo: Algo_RSA_PSS_SHA512,
+			Expected:    ErrCode(""),
+		},
+
+		// Required Fields Validation Tests
+		{
+			Name: "ValidRequiredFields",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components: []componentID{
+						{Name: "content-digest"},
+						{Name: "@method"},
+						{Name: "@target-uri"},
+						{Name: "authorization"}, // Extra field is OK
+					},
+					MetadataParams: []Metadata{},
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				RequiredFields: Fields("content-digest", "@method", "@target-uri"),
+			},
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrCode(""),
+		},
+		{
+			Name: "MissingRequiredField",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components: []componentID{
+						{Name: "content-digest"},
+						{Name: "@method"},
+						// Missing @target-uri
+					},
+					MetadataParams: []Metadata{},
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				RequiredFields: Fields("content-digest", "@method", "@target-uri"),
+			},
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Signature missing required field '@target-uri'",
+		},
+		{
+			Name: "CaseInsensitiveFieldMatching",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components: []componentID{
+						{Name: "content-digest"}, // lowercase in signature
+						{Name: "authorization"},  // lowercase in signature
+					},
+					MetadataParams: []Metadata{},
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				RequiredFields: Fields("Content-Digest", "Authorization"), // Mixed case in profile
+			},
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrCode(""),
+		},
+		{
+			Name: "NoRequiredFields",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{}, // Empty components is OK when no fields required
+					MetadataParams: []Metadata{},
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				RequiredFields: []SignedField{}, // No fields required
+			},
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrCode(""),
+		},
+
+		// Required Metadata Validation Tests
+		{
+			Name: "ValidRequiredMetadata",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated, MetaKeyID, MetaNonce}, // Extra metadata is OK
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				RequiredMetadata: []Metadata{MetaCreated, MetaKeyID},
+			},
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrCode(""),
+		},
+		{
+			Name: "MissingRequiredMetadata",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated}, // Missing MetaKeyID
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				RequiredMetadata: []Metadata{MetaCreated, MetaKeyID},
+			},
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Signature missing required meta parameter 'keyid'",
+		},
+
+		// Disallowed Metadata Validation Tests
+		{
+			Name: "DisallowedMetaAlgorithm",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{{Name: "content-digest"}, {Name: "@method"}, {Name: "@target-uri"}},
+					MetadataParams: []Metadata{MetaCreated, MetaKeyID, MetaAlgorithm}, // This should be disallowed
+					MetadataValues: nil,
+				},
+			},
+			Profile:     DefaultVerifyProfile,
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Signature contains disallowed meta parameter 'alg'",
+		},
+		{
+			Name: "NoDisallowedMetadata",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated, MetaKeyID}, // Only allowed metadata
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				DisallowedMetadata: []Metadata{MetaAlgorithm},
+			},
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrCode(""),
+		},
+
+		// Complex Validation Tests (Multiple Rules)
+		{
+			Name: "ComplexValidSignature",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components: []componentID{
+						{Name: "content-digest"},
+						{Name: "@method"},
+						{Name: "@target-uri"},
+					},
+					MetadataParams: []Metadata{MetaCreated, MetaKeyID},
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				SignatureLabel:     "sig1",
+				AllowedAlgorithms:  []Algorithm{Algo_ECDSA_P256_SHA256, Algo_ED25519},
+				RequiredFields:     Fields("content-digest", "@method", "@target-uri"),
+				RequiredMetadata:   []Metadata{MetaCreated, MetaKeyID},
+				DisallowedMetadata: []Metadata{MetaAlgorithm},
+			},
+			KeySpecAlgo: Algo_ED25519,
+			Expected:    ErrCode(""),
+		},
+		{
+			Name: "ComplexInvalidSignature_MultipleFailures",
+			Sig: extractedSignature{
+				Label:     "sig2", // Wrong label
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components: []componentID{
+						{Name: "content-digest"},
+						// Missing @method and @target-uri
+					},
+					MetadataParams: []Metadata{MetaAlgorithm}, // Disallowed metadata, missing required
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				SignatureLabel:     "sig1",
+				AllowedAlgorithms:  []Algorithm{Algo_ECDSA_P256_SHA256},
+				RequiredFields:     Fields("content-digest", "@method", "@target-uri"),
+				RequiredMetadata:   []Metadata{MetaCreated, MetaKeyID},
+				DisallowedMetadata: []Metadata{MetaAlgorithm},
+			},
+			KeySpecAlgo: Algo_RSA_PSS_SHA512, // Not allowed algorithm
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Signature label 'sig2' does not match required label 'sig1'", // First error encountered
+		},
+
+		// DefaultVerifyProfile Tests
+		{
+			Name: "DefaultVerifyProfile_Valid",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components: []componentID{
+						{Name: "content-digest"},
+						{Name: "@method"},
+						{Name: "@target-uri"},
+					},
+					MetadataParams: []Metadata{MetaCreated, MetaKeyID},
+					MetadataValues: nil,
+				},
+			},
+			Profile:     DefaultVerifyProfile,
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrCode(""),
+		},
+		{
+			Name: "DefaultVerifyProfile_InvalidAlgorithm",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components: []componentID{
+						{Name: "content-digest"},
+						{Name: "@method"},
+						{Name: "@target-uri"},
+					},
+					MetadataParams: []Metadata{MetaCreated, MetaKeyID},
+					MetadataValues: nil,
+				},
+			},
+			Profile:     DefaultVerifyProfile,
+			KeySpecAlgo: Algo_RSA_v1_5_sha256, // Not in DefaultVerifyProfile allowed algorithms
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Algorithm 'rsa-v1_5-sha256' is not in allowed algorithms list",
+		},
+		{
+			Name: "DefaultVerifyProfile_MissingRequiredFields",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components: []componentID{
+						{Name: "content-digest"},
+						// Missing @method and @target-uri required by DefaultVerifyProfile
+					},
+					MetadataParams: []Metadata{MetaCreated, MetaKeyID},
+					MetadataValues: nil,
+				},
+			},
+			Profile:     DefaultVerifyProfile,
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Signature missing required field '@method'",
+		},
+
+		// Edge Cases
+		{
+			Name: "EmptySignatureComponents",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{}, // No components
+					MetadataParams: []Metadata{},
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				RequiredFields: Fields("content-digest"), // But we require some fields
+			},
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Signature missing required field 'content-digest'",
+		},
+		{
+			Name: "EmptyMetadata",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{}, // No metadata
+					MetadataValues: nil,
+				},
+			},
+			Profile: VerifyProfile{
+				RequiredMetadata: []Metadata{MetaCreated}, // But we require some metadata
+			},
+			KeySpecAlgo: Algo_ECDSA_P256_SHA256,
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Signature missing required meta parameter 'created'",
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			err := tc.Profile.validate(tc.Sig, tc.KeySpecAlgo)
+			if tc.Expected == ErrCode("") {
+				sigtest.Diff(t, nil, err, "Diff")
+				return
+			}
+			var sigErr *SignatureError
+			if errors.As(err, &sigErr) {
+				sigtest.Diff(t, tc.Expected, sigErr.Code, "Unexpected error code")
+				if tc.ExpectedMsg != "" && err != nil {
+					if !strings.Contains(sigErr.Message, tc.ExpectedMsg) {
+						t.Errorf("Expected error message to contain '%s', got: %s", tc.ExpectedMsg, err.Error())
+					}
+				}
+			} else {
+				t.Fatal("Error was not type *SignatureError")
+			}
+
+		})
+	}
+}
+
+func TestValidateTiming(t *testing.T) {
+	now := time.Now()
+
+	testcases := []struct {
+		Name        string
+		Sig         extractedSignature
+		Profile     VerifyProfile
+		Expected    ErrCode // Expected ErrCode if an error. Empty string if expecting no error
+		ExpectedMsg string
+	}{
+		// DisableTimeEnforcement Tests
+		{
+			Name: "TimeEnforcementDisabled_ExpiredSignature",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated, MetaExpires},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(now.Add(-2 * time.Hour).Unix()), // Very old
+							MetaExpires: int64(now.Add(-1 * time.Hour).Unix()), // Expired
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				DisableTimeEnforcement: true, // Should ignore all timing issues
+			},
+			Expected: ErrCode(""),
+		},
+		{
+			Name: "TimeEnforcementEnabled_SameSignature",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated, MetaExpires},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(now.Add(-2 * time.Hour).Unix()),
+							MetaExpires: int64(now.Add(-1 * time.Hour).Unix()),
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				DisableTimeEnforcement: false,
+				CreatedValidDuration:   time.Minute * 5, // Only 5 minutes allowed
+			},
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "is older than allowed duration",
+		},
+
+		// Created Time Validation Tests
+		{
+			Name: "ValidCreatedTime",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(now.Add(-2 * time.Minute).Unix()), // 2 minutes ago
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				CreatedValidDuration: time.Minute * 5, // Allow 5 minutes
+			},
+			Expected: ErrCode(""),
+		},
+		{
+			Name: "CreatedTimeTooOld",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(now.Add(-10 * time.Minute).Unix()), // 10 minutes ago
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				CreatedValidDuration: time.Minute * 5, // Only allow 5 minutes
+			},
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "is older than allowed duration",
+		},
+		{
+			Name: "CreatedTimeInFuture",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(now.Add(5 * time.Minute).Unix()), // 5 minutes in future
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				CreatedValidDuration: time.Minute * 10,
+			},
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "is too far in the future",
+		},
+		{
+			Name: "CreatedTimeSlightlyInFuture_Allowed",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(now.Add(30 * time.Second).Unix()), // 30 seconds in future (clock skew)
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				CreatedValidDuration: time.Minute * 10,
+			},
+			Expected: ErrCode(""), // Should be allowed due to clock skew tolerance
+		},
+		{
+			Name: "NoCreatedValidDuration_NoTimeLimit",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(now.Add(-24 * time.Hour).Unix()), // 24 hours ago
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				CreatedValidDuration: 0, // No duration limit
+			},
+			Expected: ErrCode(""), // Should be allowed
+		},
+
+		// Expires Time Validation Tests
+		{
+			Name: "ValidExpiresTime",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaExpires},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaExpires: int64(now.Add(5 * time.Minute).Unix()), // Expires in 5 minutes
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				DisableExpirationEnforcement: false,
+			},
+			Expected: ErrCode(""),
+		},
+		{
+			Name: "ExpiredSignature",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaExpires},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaExpires: int64(now.Add(-5 * time.Minute).Unix()), // Expired 5 minutes ago
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				DisableExpirationEnforcement: false,
+			},
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Signature expired at",
+		},
+		{
+			Name: "ExpiredSignature_WithinSkewTolerance",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaExpires},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaExpires: int64(now.Add(-30 * time.Second).Unix()), // Expired 30 seconds ago
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				DisableExpirationEnforcement: false,
+				ExpiredSkew:                  time.Minute, // Allow 1 minute skew
+			},
+			Expected: ErrCode(""), // Should be allowed within skew tolerance
+		},
+		{
+			Name: "ExpirationEnforcementDisabled",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaExpires},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaExpires: int64(now.Add(-1 * time.Hour).Unix()), // Very expired
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				DisableExpirationEnforcement: true, // Should ignore expiration
+			},
+			Expected: ErrCode(""),
+		},
+
+		// Complex Timing Tests
+		{
+			Name: "BothCreatedAndExpires_Valid",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated, MetaExpires},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(now.Add(-2 * time.Minute).Unix()), // 2 minutes ago
+							MetaExpires: int64(now.Add(3 * time.Minute).Unix()),  // 3 minutes from now
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				CreatedValidDuration:         time.Minute * 5,
+				DisableExpirationEnforcement: false,
+			},
+			Expected: ErrCode(""),
+		},
+		{
+			Name: "BothCreatedAndExpires_CreatedTooOld",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated, MetaExpires},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(now.Add(-10 * time.Minute).Unix()), // 10 minutes ago
+							MetaExpires: int64(now.Add(3 * time.Minute).Unix()),   // 3 minutes from now
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				CreatedValidDuration:         time.Minute * 5, // Only allow 5 minutes
+				DisableExpirationEnforcement: false,
+			},
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "is older than allowed duration", // Created validation fails first
+		},
+		{
+			Name: "BothCreatedAndExpires_Expired",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated, MetaExpires},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(now.Add(-2 * time.Minute).Unix()), // 2 minutes ago (valid)
+							MetaExpires: int64(now.Add(-3 * time.Minute).Unix()), // Expired 3 minutes ago
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				CreatedValidDuration:         time.Minute * 5,
+				DisableExpirationEnforcement: false,
+			},
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Signature expired at",
+		},
+
+		// Error Handling Tests
+		{
+			Name: "InvalidCreatedMetadata",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaCreated},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							// Missing MetaCreated value
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				CreatedValidDuration: time.Minute * 5,
+			},
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Failed to get created timestamp",
+		},
+		{
+			Name: "InvalidExpiresMetadata",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{MetaExpires},
+					MetadataValues: testMetadataProvider{
+						values: map[Metadata]any{
+							// Missing MetaExpires value
+						},
+					},
+				},
+			},
+			Profile: VerifyProfile{
+				DisableExpirationEnforcement: false,
+			},
+			Expected:    ErrSigProfile,
+			ExpectedMsg: "Failed to get expires timestamp",
+		},
+
+		// No Metadata Present Tests
+		{
+			Name: "NoCreatedMetadata_NoValidation",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{}, // No created metadata
+					MetadataValues: testMetadataProvider{values: map[Metadata]any{}},
+				},
+			},
+			Profile: VerifyProfile{
+				CreatedValidDuration: time.Minute * 5,
+			},
+			Expected: ErrCode(""), // Should pass since no created time to validate
+		},
+		{
+			Name: "NoExpiresMetadata_NoValidation",
+			Sig: extractedSignature{
+				Label:     "sig1",
+				Signature: []byte{},
+				Input: sigBaseInput{
+					Components:     []componentID{},
+					MetadataParams: []Metadata{}, // No expires metadata
+					MetadataValues: testMetadataProvider{values: map[Metadata]any{}},
+				},
+			},
+			Profile: VerifyProfile{
+				DisableExpirationEnforcement: false,
+			},
+			Expected: ErrCode(""), // Should pass since no expires time to validate
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.Name, func(t *testing.T) {
+			err := tc.Profile.validateTiming(tc.Sig)
+			if tc.Expected == ErrCode("") {
+				sigtest.Diff(t, nil, err, "Diff")
+				return
+			}
+			var sigErr *SignatureError
+			if errors.As(err, &sigErr) {
+				sigtest.Diff(t, tc.Expected, sigErr.Code, "Unexpected error code")
+				if tc.ExpectedMsg != "" && err != nil {
+					if !strings.Contains(sigErr.Message, tc.ExpectedMsg) {
+						t.Errorf("Expected error message to contain '%s', got: %s", tc.ExpectedMsg, err.Error())
+					}
+				}
+			} else {
+				t.Fatal("Error was not type *SignatureError")
+			}
+		})
+	}
+}

--- a/validate_test.go
+++ b/validate_test.go
@@ -27,7 +27,11 @@ func TestValidateProfile(t *testing.T) {
 				Input: sigBaseInput{
 					Components:     []componentID{{Name: "content-digest"}, {Name: "@method"}, {Name: "@target-uri"}},
 					MetadataParams: []Metadata{MetaCreated, MetaKeyID},
-					MetadataValues: nil,
+					MetadataValues: fixedMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(1755206251),
+						},
+					},
 				},
 			},
 			Profile: VerifyProfile{
@@ -221,7 +225,11 @@ func TestValidateProfile(t *testing.T) {
 				Input: sigBaseInput{
 					Components:     []componentID{},
 					MetadataParams: []Metadata{MetaCreated, MetaKeyID, MetaNonce}, // Extra metadata is OK
-					MetadataValues: nil,
+					MetadataValues: fixedMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(1755206251),
+						},
+					},
 				},
 			},
 			Profile: VerifyProfile{
@@ -274,7 +282,11 @@ func TestValidateProfile(t *testing.T) {
 				Input: sigBaseInput{
 					Components:     []componentID{},
 					MetadataParams: []Metadata{MetaCreated, MetaKeyID}, // Only allowed metadata
-					MetadataValues: nil,
+					MetadataValues: fixedMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(1755206251),
+						},
+					},
 				},
 			},
 			Profile: VerifyProfile{
@@ -297,7 +309,11 @@ func TestValidateProfile(t *testing.T) {
 						{Name: "@target-uri"},
 					},
 					MetadataParams: []Metadata{MetaCreated, MetaKeyID},
-					MetadataValues: nil,
+					MetadataValues: fixedMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(1755206251),
+						},
+					},
 				},
 			},
 			Profile: VerifyProfile{
@@ -349,7 +365,11 @@ func TestValidateProfile(t *testing.T) {
 						{Name: "@target-uri"},
 					},
 					MetadataParams: []Metadata{MetaCreated, MetaKeyID},
-					MetadataValues: nil,
+					MetadataValues: fixedMetadataProvider{
+						values: map[Metadata]any{
+							MetaCreated: int64(1755206251),
+						},
+					},
 				},
 			},
 			Profile:     DefaultVerifyProfile,
@@ -853,7 +873,7 @@ func TestValidateTiming(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.Name, func(t *testing.T) {
-			err := tc.Profile.validateTiming(tc.Sig)
+			err := tc.Profile.validateTiming(tc.Sig, now)
 			if tc.Expected == ErrCode("") {
 				sigtest.Diff(t, nil, err, "Diff")
 				return

--- a/verify_test.go
+++ b/verify_test.go
@@ -11,7 +11,8 @@ import (
 	"github.com/remitly-oss/httpsig-go/sigtest"
 )
 
-func TestVerify(t *testing.T) {
+// TestVerifyResult ensures the VerifyReuslt contains the expected shape.
+func TestVerifyResult(t *testing.T) {
 	testcases := []struct {
 		Name         string
 		RequestFile  string
@@ -84,7 +85,7 @@ func TestVerify(t *testing.T) {
 			if tc.AddDebugInfo {
 				req = req.WithContext(httpsig.SetAddDebugInfo(req.Context()))
 			}
-			actual, err := httpsig.Verify(req, tc.Keys, httpsig.VerifyProfile{SignatureLabel: tc.Label})
+			actual, err := httpsig.Verify(req, tc.Keys, httpsig.VerifyProfile{SignatureLabel: tc.Label, DisableTimeEnforcement: true})
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
This adds logic to enforce the VerifyProfile settings - allowed algorithms, required metadata, timing related options, etc.